### PR TITLE
persist feed state between vue-router state changes

### DIFF
--- a/src/web/components/pages/Post.vue
+++ b/src/web/components/pages/Post.vue
@@ -16,7 +16,7 @@
       </PageHeader>
 
       <PageRibbon>
-        <IndeterminateProgressBar v-if="!post_" />
+        <IndeterminateProgressBar v-if="loading_" />
 
         <template v-if="post_">
           <Post :class="$style.Post" :post="post_" />
@@ -25,6 +25,7 @@
             :class="$style.Comments"
             :post="post_"
             :comments="post_.comments"
+            v-if="post_.comments"
           >
           </CommentThread>
         </template>
@@ -43,6 +44,8 @@ import PageFooter from '@/src/web/components/layout/PageFooter';
 import PageHeader from '@/src/web/components/layout/PageHeader';
 import PageRibbon from '@/src/web/components/layout/PageRibbon';
 import Post from '@/src/web/components/layout/Post';
+
+import FeedStore from '@/src/web/stores/Feed';
 
 import apiFetch from '@/src/web/helpers/net/apiFetch';
 
@@ -69,6 +72,11 @@ export default {
     'route$.params.id': {
       immediate: true,
       handler() {
+        const feedPost = FeedStore.state.posts[this.$route.params.id];
+        if (feedPost) {
+          this.post_ = feedPost;
+        }
+
         this.loading_ = true;
         apiFetch('aurora/posts/get', { id: this.$route.params.id })
           .then(({ post }) => {

--- a/src/web/components/pages/Post.vue
+++ b/src/web/components/pages/Post.vue
@@ -16,10 +16,14 @@
       </PageHeader>
 
       <PageRibbon>
-        <IndeterminateProgressBar v-if="loading_" />
+        <template v-if="!post_">
+          <IndeterminateProgressBar v-if="loading_" />
+        </template>
 
         <template v-if="post_">
           <Post :class="$style.Post" :post="post_" />
+
+          <IndeterminateProgressBar v-if="loading_" />
 
           <CommentThread
             :class="$style.Comments"

--- a/src/web/debug/console.js
+++ b/src/web/debug/console.js
@@ -1,9 +1,11 @@
 import CurrentUserStore from '@/src/web/stores/CurrentUser';
+import FeedStore from '@/src/web/stores/Feed';
 import WindowSizeStore from '@/src/web/stores/WindowSize';
 
-window.__unfck__ = {
+window.__mozillabuilders__ = {
   stores: {
     CurrentUserStore,
+    FeedStore,
     WindowSizeStore,
   },
 };

--- a/src/web/stores/Feed.js
+++ b/src/web/stores/Feed.js
@@ -25,7 +25,7 @@ export default createStore('FeedStore', {
       },
     },
 
-    allPosts: {},
+    posts: {},
   },
 
   actions: {
@@ -50,7 +50,7 @@ export default createStore('FeedStore', {
       const feed = state.feeds[feedName];
 
       for (const post of posts) {
-        Vue.set(state.allPosts, post.id, post);
+        Vue.set(state.posts, post.id, post);
         feed.posts.push(post);
       }
 

--- a/src/web/stores/Feed.js
+++ b/src/web/stores/Feed.js
@@ -1,0 +1,64 @@
+import Vue from 'vue';
+
+import apiFetch from '@/src/web/helpers/net/apiFetch';
+import createStore from '@/src/web/helpers/store/createStore';
+
+export default createStore('FeedStore', {
+  state: {
+    feeds: {
+      new: {
+        posts: [],
+        cursor: {
+          first: null,
+          last: null,
+          next: null,
+        },
+      },
+
+      hot: {
+        posts: [],
+        cursor: {
+          first: null,
+          last: null,
+          next: null,
+        },
+      },
+    },
+
+    allPosts: {},
+  },
+
+  actions: {
+    async loadNextPage({ state, commit }, feedName) {
+      const feed = state.feeds[feedName];
+
+      if (feed.cursor.first && !feed.cursor.next) {
+        return;
+      }
+
+      const { posts, cursor } = await apiFetch('aurora/posts/query', {
+        index: feedName,
+        cursor: feed.cursor.next,
+      });
+
+      commit('extendFeed', { feedName, posts, cursor });
+    },
+  },
+
+  mutations: {
+    extendFeed(state, { feedName, posts, cursor }) {
+      const feed = state.feeds[feedName];
+
+      for (const post of posts) {
+        Vue.set(state.allPosts, post.id, post);
+        feed.posts.push(post);
+      }
+
+      if (!feed.cursor.first) {
+        Vue.set(feed.cursor, 'first', cursor.current);
+      }
+      Vue.set(feed.cursor, 'last', cursor.current);
+      Vue.set(feed.cursor, 'next', cursor.next || null);
+    },
+  },
+});


### PR DESCRIPTION
We shouldn't reload the feed every time you enter peek view and then go back to the feed. Feels slow and lacks continuity.